### PR TITLE
依存ライブラリーのアップデート & ビルド・エラーの修正

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.31'
     ext.sora_android_sdk_version = '2020.3'
 
     repositories {
@@ -10,7 +10,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,13 +7,14 @@ buildscript {
     repositories {
         jcenter()
         google()
+        gradlePluginPortal()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.21.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     }
 
     // アプリから参照する設定項目

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -46,10 +46,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "com.google.android.material:material:1.2.1"
+    implementation "com.google.android.material:material:1.3.0"
 
-    implementation "org.permissionsdispatcher:permissionsdispatcher:4.7.0"
-    kapt "org.permissionsdispatcher:permissionsdispatcher-processor:4.7.0"
+    implementation "org.permissionsdispatcher:permissionsdispatcher:4.8.0"
+    kapt "org.permissionsdispatcher:permissionsdispatcher-processor:4.8.0"
 
     // Sora Android SDK
     if (findProject(':sora-android-sdk') != null) {

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -108,7 +108,7 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        override fun onAddLocalStream(mediaChannel: SoraMediaChannel, ms: MediaStream) {
+        override fun onAddLocalStream(mediaChannel: SoraMediaChannel, ms: MediaStream, videoSource: VideoSource?) {
             Log.d(TAG, "onAddLocalStream")
             runOnUiThread {
                 if (ms.videoTracks.size > 0) {


### PR DESCRIPTION
## 変更内容

- 依存ライブラリーをアップデートしました
   - 詳細は https://github.com/shiguredo/sora-android-sdk-samples/pull/22 と同様です
- sora-android-sdk の更新に伴い発生していたビルド・エラーを修正しました

作業後の `./gradlew dependencyUpdates` の実行結果は以下の通りです

```
$ ./gradlew dependencyUpdates

> Configure project :quickstart
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.

> Task :dependencyUpdates
dependencyUpdates.resolutionStrategy: Remove the assignment operator, '=', when setting this task property

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - androidx.appcompat:appcompat:1.2.0
 - com.android.tools.build:gradle:4.1.2
 - com.github.ben-manes:gradle-versions-plugin:0.38.0
 - com.github.dcendents:android-maven-gradle-plugin:2.1
 - com.github.shiguredo:sora-android-sdk:2020.3
 - com.google.android.material:material:1.3.0
 - org.permissionsdispatcher:permissionsdispatcher:4.8.0
 - org.permissionsdispatcher:permissionsdispatcher-processor:4.8.0

The following dependencies have later milestone versions:
 - org.jetbrains.kotlin:kotlin-android-extensions [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-android-extensions-runtime [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-annotation-processing-gradle [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-gradle-plugin [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-reflect [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7 [1.4.31 -> 1.5.0-M1]
     https://kotlinlang.org/

Gradle release-candidate updates:
 - Gradle: [6.8.3: UP-TO-DATE]

Generated report file build/dependencyUpdates/report.txt

BUILD SUCCESSFUL in 2s
1 actionable task: 1 executed
```