### PR TITLE
Feature/remove jcenter dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- 依存ライブラリーのバージョンを上げる
+  - `com.android.tools.build:gradle` を 4.2.2 に上げる
+- JCenter への参照を取り除く
 
 ## sora-andoroid-sdk-2021.1.1
 
@@ -53,7 +58,6 @@
 ### CHANGE
 
 - `MODE_IN_COMMUNICATION` を使うように変更する
-
 
 ## 1.8.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,12 @@ buildscript {
     ext.sora_android_sdk_version = '2021.1.1'
 
     repositories {
-        jcenter()
         google()
         gradlePluginPortal()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
+        classpath 'com.android.tools.build:gradle:4.2.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
@@ -27,9 +27,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
         maven { url 'https://jitpack.io' }
+        mavenCentral()
     }
 }
 

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.3.0"
 
-    implementation "org.permissionsdispatcher:permissionsdispatcher:4.8.0"
-    kapt "org.permissionsdispatcher:permissionsdispatcher-processor:4.8.0"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.8.0"
+    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.8.0"
 
     // Sora Android SDK
     if (findProject(':sora-android-sdk') != null) {

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.3.0"
 
-    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.8.0"
+    implementation "com.github.permissions-dispatcher.permissionsdispatcher:permissionsdispatcher:4.8.0"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.8.0"
 
     // Sora Android SDK


### PR DESCRIPTION
## 変更内容

- JCenter への参照を取り除きました
- `com.android.tools.build:gradle` を 4.2.2 に更新しました