### PR TITLE
permissions-dispatcher を Maven Central から取得する

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        maven { url 'https://jitpack.io' }
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.3.0"
 
-    implementation "com.github.permissions-dispatcher.permissionsdispatcher:permissionsdispatcher:4.8.0"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.8.0"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.8.0"
 
     // Sora Android SDK


### PR DESCRIPTION
## 変更内容

- permissions-dispatcher を Maven Central から取得するように修正しました
  - 修正前は permissions-dispatcher を JitPack から取得していました