### PR TITLE
シグナリング URL の設定を build.gradle から gradle.properties に移動する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,9 +11,13 @@
 
 ## develop
 
+### UPDATE
+
 - 依存ライブラリーのバージョンを上げる
   - `com.android.tools.build:gradle` を 4.2.2 に上げる
 - JCenter への参照を取り除く
+- シグナリングエンドポイント URL の設定を `/build.gradle` から `/gradle.properties.example` に移動する
+
 
 ## sora-andoroid-sdk-2021.1.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,6 @@ buildscript {
         classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
     }
 
-    // アプリから参照する設定項目
-    ext.signaling_endpoint = "wss://sora.example.com/signaling"
-    ext.channel_id         = "sora"
-
     // デバッグ用: true に設定すると wss ではなく ws で接続できる
     ext.usesCleartextTraffic = false
 }

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -18,6 +18,6 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 
-# Overwrite sora Signaling endpoint in build.gradle's ext.signaling_endpoint
+# Setting Sora's signaling endpoint and channel_id
 signaling_endpoint = wss://sora.example.com/signaling
 channel_id         = sora

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -19,5 +19,5 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 
 # Overwrite sora Signaling endpoint in build.gradle's ext.signaling_endpoint
-# signaling_endpoint = ws://192.0.2.10:50000/signaling
-# channel_id         = sora
+signaling_endpoint = wss://sora.example.com/signaling
+channel_id         = sora


### PR DESCRIPTION
ビルドしてアプリケーションが動作するところまで確認できています。
修正のポイントは以下の通りです

- signaling_endpoint, channel_id の設定を build.gradle から gradle.properties に移動しています
- signaling_endpoint の初期 URL を ws から wss に変更しています。usesCleartextTraffic = false が設定されており、HTTPS を前提とした設定になっているためそれにあわせて修正しています
- -samples と SDK ドキュメントもこちらにあわせて修正します。
