### PR TITLE
シグナリング接続時に送信するメタデータを外部ファイルから設定できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [ADD] シグナリング接続時に送信するメタデータを外部ファイルから設定できるようにする
+  - @miosakuma
+  
 ## sora-andoroid-sdk-2021.3
 
 - [UPDATE] システム条件を更新する

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -21,3 +21,9 @@ android.useAndroidX=true
 # Setting Sora's signaling endpoint and channel_id
 signaling_endpoint = wss://sora.example.com/signaling
 channel_id         = sora
+
+# Setting Signaling Metadata.
+# Quotes must be double escaped.
+# e.g.) signaling_metadata = {\\"spam\\":\\"egg\\"}
+# This setting is required. If you do not want to use it, set it to blank.
+signaling_metadata =

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -17,6 +17,7 @@ android {
         // アプリで参照する設定を BuildConfig / resource に書き込む。
         buildConfigField("String", "SIGNALING_ENDPOINT", "\"${signaling_endpoint}\"")
         buildConfigField("String", "CHANNEL_ID",         "\"${channel_id}\"")
+        buildConfigField("String", "SIGNALING_METADATA", "\"${signaling_metadata}\"")
 
         manifestPlaceholders = [usesCleartextTraffic: usesCleartextTraffic]
     }
@@ -44,6 +45,8 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
+
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.3.0"

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -5,19 +5,20 @@ import android.content.Context
 import android.graphics.Color
 import android.media.AudioManager
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import android.util.Log
+import com.google.android.material.snackbar.Snackbar
+import com.google.gson.*
 import jp.shiguredo.sora.sdk.camera.CameraCapturerFactory
 import jp.shiguredo.sora.sdk.channel.SoraMediaChannel
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
 import jp.shiguredo.sora.sdk.channel.signaling.message.PushMessage
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
+import kotlinx.android.synthetic.main.activity_main.*
 import org.webrtc.*
 import permissions.dispatcher.*
-import kotlinx.android.synthetic.main.activity_main.*
 
 @RuntimePermissions
 class MainActivity : AppCompatActivity() {
@@ -152,6 +153,7 @@ class MainActivity : AppCompatActivity() {
                 context           = this,
                 signalingEndpoint = BuildConfig.SIGNALING_ENDPOINT,
                 channelId         = BuildConfig.CHANNEL_ID,
+                signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java),
                 mediaOption       = option,
                 listener          = channelListener)
         mediaChannel!!.connect()


### PR DESCRIPTION
下記 PR と同様の内容を android-sdk-quickstart に反映したものです。
https://github.com/shiguredo/sora-android-sdk-samples/pull/42