### PR TITLE
Feature/dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.6.10'
     ext.sora_android_sdk_version = '2022.1.0'
 
     repositories {
@@ -10,11 +10,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.38.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.41.0"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -54,13 +54,13 @@ ktlint {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
 
     implementation "androidx.appcompat:appcompat:1.2.0"
     implementation "com.google.android.material:material:1.3.0"
 
-    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.8.0"
-    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.8.0"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.9.1"
+    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.9.1"
 
     // Sora Android SDK
     if (findProject(':sora-android-sdk') != null) {

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
@@ -54,7 +53,6 @@ ktlint {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
-    implementation "org.jetbrains.kotlin:kotlin-reflect:${kotlin_version}"
 
     implementation 'com.google.code.gson:gson:2.8.6'
 


### PR DESCRIPTION
不要になったライブラリを削除し、その他のライブラリのバージョンを上げます。

削除するライブラリ:

- com.github.dcendents.android-maven
- org.jetbrains.kotlin:kotlin-reflect

アップデートするライブラリ:

- Kotlin 1.6.10
- com.android.tools.build:gradle:7.0.4
- com.github.ben-manes:gradle-versions-plugin:0.41.0
- com.google.code.gson:gson:2.8.9
- com.github.permissions-dispatcher:permissionsdispatcher:4.8.0

以下のライブラリは minCompileSdk の指定 (及び compileSdkVersion, targetSdkVersion の変更) が必要になるので見送ります。

- androidx.appcompat:appcompat
- com.google.android.material:material