### PR TITLE
利用ライブラリをアップデートする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,19 @@
 
 ## develop
 
+- [UPDATE] compileSdkVersion を 31 に上げる
+  - AndroidManifest.xml の Activity に `android:exported="true"` を明示的に記載する
+- [UPDATE] Gradle のバージョンを 7.4.2 に上げる
+- [UPDATE] Gktlint のバージョンを 0.45.2 に上げる
+- [UPDATE] 依存ライブラリを更新する
+  - com.google.code.gson:gson を 2.9.0 に上げる
+  - androidx.appcompat:appcompat を 1.4.2 に上げる
+  - com.google.android.material:material を 1.6.1 に上げる
+  - com.github.permissions-dispatcher:permissionsdispatcher を 4.9.2　に上げる
+  - com.android.tools.build:gradle を 7.2.1 に上げる
+  - com.github.ben-manes:gradle-versions-plugin を 0.42.0 に上げる
+  - org.jlleitschuh.gradle:ktlint-gradle を 10.3.0 に上げる
+
 ## sora-andoroid-sdk-2022.2.0
 
 - [UPDATE] システム条件を更新する

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.41.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.2.1"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.3.0"
     }
 
     // デバッグ用: true に設定すると wss ではなく ws で接続できる

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "jp.shiguredo.sora.quickstart"
@@ -45,7 +45,7 @@ android {
 }
 
 ktlint {
-    version = "0.43.2"
+    version = "0.45.2"
     android = false
     outputToConsole = true
     reporters {
@@ -57,13 +57,13 @@ ktlint {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
 
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "com.google.android.material:material:1.3.0"
+    implementation "androidx.appcompat:appcompat:1.4.2"
+    implementation "com.google.android.material:material:1.6.1"
 
-    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.9.1"
-    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.9.1"
+    implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.9.2"
+    kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.9.2"
 
     // Sora Android SDK
     if (findProject(':sora-android-sdk') != null) {

--- a/quickstart/src/main/AndroidManifest.xml
+++ b/quickstart/src/main/AndroidManifest.xml
@@ -25,7 +25,9 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="${usesCleartextTraffic}"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
依存パッケージのアップデートを行っています。動作確認済みです。
また、アップデートに必要であったため、 compileSdkVersion 31 に上げる変更を行なっています。
クイックスタートやサンプルは SDK 本体ではないためアップデートしてよいと考えています。

特記事項

- Kotlin の  1.7.0 関連のアップデートは見送っています。最近リリースされたばかりであったためです
- Android Studio のバージョンを 2021.2.1 にあげていただく必要があります
- AndroidManifest .xml の修正は compileSdkVersion 31 に上げるに伴い必要になりました
https://developer.android.com/about/versions/12/behavior-changes-12?hl=ja#exported
