### PR TITLE
依存ライブラリのバージョンアップ

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@
 - [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
     - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
+    - com.android.tools.build:gradle を 7.4.2 に上げる
     - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる
     - org.jlleitschuh.gradle:ktlint-gradle を 11.3.1 に上げる
     - com.google.code.gson:gson を 2.10.1 に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,25 @@
     - バグ修正
 
 ## develop
+
 - [UPDATE] システム条件を更新する
     - Android Studio 2022.1.1 以降
     - WebRTC SFU Sora 2022.2.0 以降
     - @miosakuma
+- [UPDATE] `compileSdkVersion` を 33 に上げる
+    - @miosakuma
+- [UPDATE] `targetSdkVersion` を 33 に上げる
+    - @miosakuma
+- [UPDATE] Kotlin のバージョンを 1.8.10 に上げる
+    - @miosakuma
+- [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
+    - @miosakuma
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+    - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる
+    - org.jlleitschuh.gradle:ktlint-gradle を 11.3.1 に上げる
+    - com.google.code.gson:gson を 2.10.1 に上げる
+    - androidx.appcompat:appcompat を 1.6.1 に上げる
+    - com.google.android.material:material: を 1.8.0 に上げる
 
 ## sora-andoroid-sdk-2022.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
     - @miosakuma
 - [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる
     - @miosakuma
+- [UPDATE] Gradle を 7.6.1 に上げる
+    - @miosakuma
 - [UPDATE] 依存ライブラリーのバージョンを上げる
     - com.android.tools.build:gradle を 7.4.2 に上げる
     - com.github.ben-manes:gradle-versions-plugin を 0.46.0 に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@
     - @miosakuma
 - [UPDATE] `targetSdkVersion` を 33 に上げる
     - @miosakuma
+- [UPDATE] `minSdkVersion` を 26 に上げる
+    - @miosakuma
 - [UPDATE] Kotlin のバージョンを 1.8.10 に上げる
     - @miosakuma
 - [UPDATE] Compose Compiler のバージョンを 1.4.3 に上げる

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.8.10'
     ext.sora_android_sdk_version = 'develop-SNAPSHOT'
 
     repositories {
@@ -14,8 +14,8 @@ buildscript {
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.42.0"
-        classpath "org.jlleitschuh.gradle:ktlint-gradle:10.3.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.46.0"
+        classpath "org.jlleitschuh.gradle:ktlint-gradle:11.3.1"
     }
 
     // デバッグ用: true に設定すると wss ではなく ws で接続できる

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "jp.shiguredo.sora.quickstart"
-        minSdkVersion 21
+        minSdkVersion 26
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "jp.shiguredo.sora.quickstart"
         minSdkVersion 21
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 
@@ -57,10 +57,10 @@ ktlint {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10.1'
 
-    implementation "androidx.appcompat:appcompat:1.5.0"
-    implementation "com.google.android.material:material:1.6.1"
+    implementation "androidx.appcompat:appcompat:1.6.1"
+    implementation "com.google.android.material:material:1.8.0"
 
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.9.2"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.9.2"


### PR DESCRIPTION
sora-android-sdk-samples でも対応した依存ライブラリのアップデートについての PR です。
https://github.com/shiguredo/sora-android-sdk-samples/pull/73

sora-android-sdk-samples のレビューが完了したタイミングでこちらもマージします。