### PR TITLE
[CI] ビルド時の Java のバージョンを 17 にする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
       - name: Copy gradle.properties
         run: cp gradle.properties.example gradle.properties

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] Github Actions でのビルドを Java 17 にする
+    - @miosakuma
+
 ## sora-andoroid-sdk-2024.1.1
 
 - [UPDATE] システム条件を更新する


### PR DESCRIPTION
Github Actions のビルドでエラーとなったために Java のバージョンを 11 から 17 に変更しました。

エラーの内容の抜粋

```
> Task :quickstart:ktlintKotlinScriptFormat SKIPPED
    class file has wrong version 61.0, should be 55.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
/home/runner/work/sora-android-sdk-quickstart/sora-android-sdk-quickstart/quickstart/build/tmp/kapt3/stubs/debug/jp/shiguredo/sora/quickstart/MainActivity.java:11: error: cannot access EglBase
    private org.webrtc.EglBase egl;
                      ^
  bad class file: /home/runner/.gradle/caches/transforms-3/7120b8c571d88aae960af3aaff384d0b/transformed/shiguredo-webrtc-android-121.6167.4.0-api.jar(/org/webrtc/EglBase.class)
```

libwebrtc の Java コンパイルバージョンが version 61.0 (Java 17) に変わったためと考えられます。