### PR TITLE
Android Gradle Plugin を 8.5.0 にアップグレード

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,17 @@
 
 ## develop
 
+- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
+  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
+    - `com.android.tools.build:gradle` を 8.5.0 に上げる
+    - ビルドに利用される Gradle を 8.7 に上げる
+    - Android マニフェストからビルドファイルにパッケージを移動
+      - Android マニフェストに定義されていた package を削除
+      - ビルドファイルに namespace を追加
+  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
+    - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する
+  - @zztkm
+
 ## sora-andoroid-sdk-2024.2.0
 
 - [UPDATE] システム条件を更新する

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -32,6 +32,14 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    buildFeatures {
+        // AGP 8.0 からデフォルトで false になった
+        // このオプションが true でないと、defaultConfig に含まれている
+        // buildConfigField オプションが無効になってしまうため、true に設定する
+        // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes
+        buildConfig true
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -50,6 +50,8 @@ android {
     viewBinding {
         enabled = true
     }
+    // AGP 8.0 からモジュールレベルの build script 内に namespace が必要になった
+    // 参考: https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl
     namespace 'jp.shiguredo.sora.quickstart'
 }
 

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -42,6 +42,7 @@ android {
     viewBinding {
         enabled = true
     }
+    namespace 'jp.shiguredo.sora.quickstart'
 }
 
 ktlint {

--- a/quickstart/src/main/AndroidManifest.xml
+++ b/quickstart/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="jp.shiguredo.sora.quickstart">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="android.support.v17.leanback"/>
 


### PR DESCRIPTION
変更内容

- [UPDATE] Android Gradle Plugin (AGP) を 8.5.0 にアップグレードする
  - Android Studion の AGP Upgrade Assistant を利用してアップグレードされた内容
    - `com.android.tools.build:gradle` を 8.5.0 に上げる
    - ビルドに利用される Gradle を 8.7 に上げる
    - Android マニフェストからビルドファイルにパッケージを移動
      - Android マニフェストに定義されていた package を削除
      - ビルドファイルに namespace を追加
  - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
    - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する

---

This pull request includes significant updates to the Android Gradle Plugin (AGP) and related build configurations. The changes involve upgrading the AGP, adjusting the Gradle version, and modifying build scripts to accommodate new AGP requirements.

### AGP and Gradle Upgrades:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R24): Documented the upgrade of AGP to 8.5.0 and Gradle to 8.7, along with the necessary adjustments in the build configuration.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated the Gradle distribution URL to use version 8.7.

### Build Script Adjustments:

* `quickstart/build.gradle`: 
  * Added `buildConfig true` to ensure `buildConfigField` options are enabled, addressing changes in AGP 8.0.
  * Added `namespace 'jp.shiguredo.sora.quickstart'` to comply with AGP 8.0 requirements for module-level build scripts.

### Manifest Changes:

* [`quickstart/src/main/AndroidManifest.xml`](diffhunk://#diff-dd7a4b13f4a2462c04fc058710c595e666e0f6f8b89d7a7aeff67b9b9fc40b3aL3-R3): Removed the `package` attribute from the Android manifest and moved it to the build file to align with AGP 8.0 requirements.
