### PR TITLE
依存ライブラリをバージョンアップする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 - [UPDATE] compileSdkVersion を 34 に上げる
   - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
   - @zztkm
+- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,11 @@
   - AGP 8.5.0 対応で発生したビルドスクリプトのエラーを手動で修正した内容
     - AGP 8.0 から buildConfig がデフォルト false になったため、true に設定する
   - @zztkm
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.google.code.gson:gson を 2.11.0 に上げる
+  - androidx.appcompat:appcompat を 1.7.0 に上げる
+  - com.google.android.material:material を 1.12.0 に上げる
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
   - androidx.appcompat:appcompat を 1.7.0 に上げる
   - com.google.android.material:material を 1.12.0 に上げる
   - @zztkm
+- [UPDATE] compileSdkVersion を 34 に上げる
+  - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
   - @zztkm
 - [UPDATE] compileSdkVersion を 34 に上げる
   - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
+  - @zztkm
 
 ## sora-andoroid-sdk-2024.2.0
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '1.9.25'
     ext.sora_android_sdk_version = 'develop-SNAPSHOT'
 
     repositories {

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "jp.shiguredo.sora.quickstart"
@@ -68,10 +68,10 @@ ktlint {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
 
-    implementation "androidx.appcompat:appcompat:1.6.1"
-    implementation "com.google.android.material:material:1.8.0"
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
 
     implementation "com.github.permissions-dispatcher:permissionsdispatcher:4.9.2"
     kapt "com.github.permissions-dispatcher:permissionsdispatcher-processor:4.9.2"


### PR DESCRIPTION
変更内容

- [UPDATE] 依存ライブラリーのバージョンを上げる
  - com.google.code.gson:gson を 2.11.0 に上げる
  - androidx.appcompat:appcompat を 1.7.0 に上げる
  - com.google.android.material:material を 1.12.0 に上げる
- [UPDATE] compileSdkVersion を 34 に上げる
  - Android API レベル 34 以降でコンパイルする必要がある依存ライブラリがあるため
- [UPDATE] Kotlin のバージョンを 1.9.25 に上げる

---
This pull request includes several updates to dependencies and configurations in the `quickstart` project. The changes primarily focus on upgrading library versions and the compile SDK version to improve compatibility and performance.

### Dependency Updates:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R24-R33): Updated the versions of `com.google.code.gson:gson`, `androidx.appcompat:appcompat`, and `com.google.android.material:material` to their latest versions.
* [`quickstart/build.gradle`](diffhunk://#diff-7d0199a57613f5c82d6b97841318ba57615ea276cd27dd17e5ae48ac7758f2ceL71-R74): Updated the `com.google.code.gson:gson` dependency to version `2.11.0`.
* [`quickstart/build.gradle`](diffhunk://#diff-7d0199a57613f5c82d6b97841318ba57615ea276cd27dd17e5ae48ac7758f2ceL71-R74): Updated the `androidx.appcompat:appcompat` dependency to version `1.7.0`.
* [`quickstart/build.gradle`](diffhunk://#diff-7d0199a57613f5c82d6b97841318ba57615ea276cd27dd17e5ae48ac7758f2ceL71-R74): Updated the `com.google.android.material:material` dependency to version `1.12.0`.

### Configuration Updates:
* [`quickstart/build.gradle`](diffhunk://#diff-7d0199a57613f5c82d6b97841318ba57615ea276cd27dd17e5ae48ac7758f2ceL7-R7): Changed `compileSdkVersion` from `33` to `34` to ensure compatibility with newer dependencies.