### PR TITLE
画面を回転させると切断される事象を回避する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] 画面回転時に接続が切断されないようにする
+  - @miosakuma
+
 ## sora-andoroid-sdk-2024.3.1
 
 **リリース日**: 2024-08-30

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,8 @@
 ## develop
 
 - [FIX] 画面回転時に Sora への接続が切断されないようにする
-  - 画面回転時にアクティビティが再作成され、 onDestroy() が実行されることにより Sora から切断する処理が実行されていた
-  - AndroidManifest.xml の `<activity>` に android:configChanges を追加して画面回転時にアクティビティが再作成を行わないように設定することで回避した
+  - 画面回転時にアクティビティが再作成され、 `onDestroy()` が実行されることにより Sora から切断する処理が実行されていた
+  - AndroidManifest.xml の `<activity>` に `android:configChanges` を追加して画面回転時にアクティビティが再作成を行わないように設定することで回避した
   - @miosakuma
 
 ## sora-andoroid-sdk-2024.3.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@
 
 ## develop
 
-- [FIX] 画面回転時に接続が切断されないようにする
+- [FIX] 画面回転時に Sora への接続が切断されないようにする
+  - 画面回転時にアクティビティが再作成され、 onDestroy() が実行されることにより Sora から切断する処理が実行されていた
+  - AndroidManifest.xml の `<activity>` に android:configChanges を追加して画面回転時にアクティビティが再作成を行わないように設定することで回避した
   - @miosakuma
 
 ## sora-andoroid-sdk-2024.3.1

--- a/quickstart/src/main/AndroidManifest.xml
+++ b/quickstart/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
画面を回転させた時に Activity が破棄され、Sora との接続が切断される問題を回避するよう修正を行いました。
すでに同様の設定が sora-android-sdk-samples には行われており、こちらには反映されていなかったため同じ値を設定するよう対応しています。

---
This pull request includes changes to prevent disconnection issues during screen rotation in the Android app. The most important changes include updating the `CHANGES.md` file and modifying the `AndroidManifest.xml` to handle configuration changes.

Fixes for disconnection issues during screen rotation:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added an entry noting the fix to prevent disconnection during screen rotation.
* [`quickstart/src/main/AndroidManifest.xml`](diffhunk://#diff-dd7a4b13f4a2462c04fc058710c595e666e0f6f8b89d7a7aeff67b9b9fc40b3aR29): Updated the `MainActivity` to handle configuration changes for orientation, screen size, smallest screen size, and screen layout.