### PR TITLE
close メソッド内で disableStopButton を呼び出すようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,11 @@
 
 ## develop
 
-- [UPDATE] Sora Android SDK を 2025.2.0-canary.1 にあげる
-  - @miosakuma
+- [UPDATE] Sora Android SDK を 2025.2.0-canary.2 にあげる
+  - @miosakuma @zztkm
+- [UPDATE] `close` メソッド内で `disableStopButton` を呼び出すようにする
+  - `close` は OkHttp のワーカースレッドで実行される可能性があり、ワーカースレッドでは UI を操作できないため、`disableStopButton` を必ず UI スレッドで呼び出すようにした
+  - @zztkm
 
 ### misc
 

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -54,7 +54,6 @@ class MainActivity : AppCompatActivity() {
         }
         binding.stopButton.setOnClickListener {
             close()
-            disableStopButton()
         }
 
         egl = EglBase.create()
@@ -173,6 +172,10 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun close() {
+        // UI 更新系処理は runOnUiThread で行う
+        runOnUiThread {
+            disableStopButton()
+        }
         mediaChannel?.disconnect()
         mediaChannel = null
         capturer?.stopCapture()


### PR DESCRIPTION
- [UPDATE] `close` メソッド内で `disableStopButton` を呼び出すようにする
  - `close` は OkHttp のワーカースレッドで実行される可能性があり、ワーカースレッドでは UI を操作できないため、`disableStopButton` を必ず UI スレッドで呼び出すようにした

---

This pull request includes updates to the Sora Android SDK and modifications to ensure UI updates are performed on the UI thread. The most important changes are listed below:

### SDK Update:

* Updated Sora Android SDK to version 2025.2.0-canary.2 in `CHANGES.md`.

### UI Thread Handling:

* Modified the `close` method in `MainActivity` to call `disableStopButton` within `runOnUiThread` to ensure it is executed on the UI thread. This prevents potential issues when `close` is called from OkHttp's worker thread.
* Removed the direct call to `disableStopButton` from the `stopButton` click listener in `MainActivity`.