### PR TITLE
シグナリング URL を複数指定できるようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 - [UPDATE] `close` メソッド内で `disableStopButton` を呼び出すようにする
   - `close` は OkHttp のワーカースレッドで実行される可能性があり、ワーカースレッドでは UI を操作できないため、`disableStopButton` を必ず UI スレッドで呼び出すようにした
   - @zztkm
+- [UPDATE] シグナリング URL を複数指定できるようにする
+  - エンドポイントを複数指定できるように変更
+  - 今まで通り 1 つのエンドポイントを指定することも可能
+  - @zztkm
 
 ### misc
 

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -18,7 +18,9 @@ org.gradle.jvmargs=-Xmx1536m
 
 android.useAndroidX=true
 
-# Setting Sora's signaling endpoint and channel_id
+# Setting Sora's signaling endpoint and channel_id.
+# Multiple signaling endpoints can be set by separating commas like below.
+# e.g.) signaling_endpoint = wss://node-01.sora.example.com/signaling, wss://node-02.sora.example.com/signaling, wss://node-03.sora.example.com/signaling
 signaling_endpoint = wss://sora.example.com/signaling
 channel_id         = sora
 

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -163,7 +163,7 @@ class MainActivity : AppCompatActivity() {
 
         mediaChannel = SoraMediaChannel(
             context = this,
-            signalingEndpoint = BuildConfig.SIGNALING_ENDPOINT,
+            signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() },
             channelId = BuildConfig.CHANNEL_ID,
             signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java),
             mediaOption = option,

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -163,7 +163,7 @@ class MainActivity : AppCompatActivity() {
 
         mediaChannel = SoraMediaChannel(
             context = this,
-            signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map{ it.trim() },
+            signalingEndpointCandidates = BuildConfig.SIGNALING_ENDPOINT.split(",").map { it.trim() },
             channelId = BuildConfig.CHANNEL_ID,
             signalingMetadata = Gson().fromJson(BuildConfig.SIGNALING_METADATA, Map::class.java),
             mediaOption = option,


### PR DESCRIPTION
- [UPDATE] シグナリング URL を複数指定できるようにする
  - エンドポイントを複数指定できるように変更
  - 今まで通り 1 つのエンドポイントを指定することも可能

---

This pull request includes changes to allow multiple signaling endpoints to be specified and updates related documentation and code accordingly. The most important changes include modifications to the `CHANGES.md` file, `gradle.properties.example` file, and `MainActivity` class.

Updates to support multiple signaling endpoints:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R19-R22): Added an update entry to specify that multiple signaling URLs can now be set.
* [`gradle.properties.example`](diffhunk://#diff-bbb7dbbc87a5eeefd96280835e68694ed252637b5b87bce74364c0e4ea56bca4L21-R23): Updated comments and example to show how to set multiple signaling endpoints separated by commas.
* [`quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt`](diffhunk://#diff-7a8dcff12b111d3a33848137a9295a672ce17203289451f2a2a876141456ee93L166-R166): Modified the `signalingEndpoint` initialization to handle multiple endpoints by splitting the string and trimming each endpoint.