### PR TITLE
`SoraMediaChannel.Listener` の実装を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,12 @@
   - 今まで通り 1 つのエンドポイントを指定することも可能
   - @zztkm
 - [UPDATE] `SoraMediaChannel.Listener` の実装を追加する
+  - `onClose` で closeEvent に応じてログを出力するようにした
+  - `onWarning` を追加した
   - `onRemoveRemoteStream` を用いてリモートストリームが削除された時に画面をクリアするようにした
+  - `onAttendeesCountUpdated` で接続数をログに出力するようにした
+  - `onOfferMessage` で Sora から受信した Offer メッセージをログに出力するようにした
+  - `onNotificationMessage` で通知内容をログに出力するようにした
   - @zztkm
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,9 @@
   - エンドポイントを複数指定できるように変更
   - 今まで通り 1 つのエンドポイントを指定することも可能
   - @zztkm
+- [UPDATE] `SoraMediaChannel.Listener` の実装を追加する
+  - `onRemoveRemoteStream` を用いてリモートストリームが削除された時に画面をクリアするようにした
+  - @zztkm
 
 ### misc
 

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -121,6 +121,13 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        override fun onRemoveRemoteStream(mediaChannel: SoraMediaChannel, label: String) {
+            Log.d(TAG, "onRemoveRemoteStream")
+            runOnUiThread {
+                binding.remoteRenderer.clearImage()
+            }
+        }
+
         override fun onAddLocalStream(mediaChannel: SoraMediaChannel, ms: MediaStream) {
             Log.d(TAG, "onAddLocalStream")
             runOnUiThread {

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -15,7 +15,10 @@ import jp.shiguredo.sora.quickstart.databinding.ActivityMainBinding
 import jp.shiguredo.sora.sdk.camera.CameraCapturerFactory
 import jp.shiguredo.sora.sdk.channel.SoraCloseEvent
 import jp.shiguredo.sora.sdk.channel.SoraMediaChannel
+import jp.shiguredo.sora.sdk.channel.data.ChannelAttendeesCount
 import jp.shiguredo.sora.sdk.channel.option.SoraMediaOption
+import jp.shiguredo.sora.sdk.channel.signaling.message.NotificationMessage
+import jp.shiguredo.sora.sdk.channel.signaling.message.OfferMessage
 import jp.shiguredo.sora.sdk.channel.signaling.message.PushMessage
 import jp.shiguredo.sora.sdk.error.SoraErrorReason
 import jp.shiguredo.sora.sdk.util.SoraLogger
@@ -160,6 +163,25 @@ class MainActivity : AppCompatActivity() {
                     Log.d(TAG, "received push data: $key=$value")
                 }
             }
+        }
+
+        override fun onAttendeesCountUpdated(
+            mediaChannel: SoraMediaChannel,
+            attendees: ChannelAttendeesCount
+        ) {
+            // 視聴者数を更新する
+            Log.d(TAG, "onAttendeesCountUpdated: $attendees")
+        }
+
+        override fun onOfferMessage(mediaChannel: SoraMediaChannel, offer: OfferMessage) {
+            Log.d(TAG, "onOfferMessage: offer=$offer")
+        }
+
+        override fun onNotificationMessage(
+            mediaChannel: SoraMediaChannel,
+            notification: NotificationMessage
+        ) {
+            Log.d(TAG, "onNotificationMessage: notification=$notification")
         }
     }
 

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -165,7 +165,6 @@ class MainActivity : AppCompatActivity() {
             mediaChannel: SoraMediaChannel,
             attendees: ChannelAttendeesCount
         ) {
-            // 視聴者数を更新する
             Log.d(TAG, "onAttendeesCountUpdated: $attendees")
         }
 

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -99,7 +99,11 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun onClose(mediaChannel: SoraMediaChannel, closeEvent: SoraCloseEvent?) {
-            Log.d(TAG, "onClose $closeEvent")
+            when {
+                closeEvent == null -> Log.i(TAG, "onClose: 切断されました")
+                closeEvent.code != 1000 -> Log.e(TAG, "onClose: エラーにより Sora から切断されました: $closeEvent")
+                else -> Log.i(TAG, "onClose: Sora から切断されました: $closeEvent")
+            }
             close()
         }
 
@@ -115,14 +119,6 @@ class MainActivity : AppCompatActivity() {
 
         override fun onWarning(mediaChannel: SoraMediaChannel, reason: SoraErrorReason) {
             Log.d(TAG, "onWarning [$reason]")
-        }
-
-        override fun onWarning(
-            mediaChannel: SoraMediaChannel,
-            reason: SoraErrorReason,
-            message: String
-        ) {
-            Log.d(TAG, "onWarning [$reason]: $message")
         }
 
         override fun onAddRemoteStream(mediaChannel: SoraMediaChannel, ms: MediaStream) {

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -106,8 +106,20 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun onError(mediaChannel: SoraMediaChannel, reason: SoraErrorReason, message: String) {
-            SoraLogger.d(TAG, "onError [$reason]: $message")
+            Log.d(TAG, "onError [$reason]: $message")
             close()
+        }
+
+        override fun onWarning(mediaChannel: SoraMediaChannel, reason: SoraErrorReason) {
+            Log.d(TAG, "onWarning [$reason]")
+        }
+
+        override fun onWarning(
+            mediaChannel: SoraMediaChannel,
+            reason: SoraErrorReason,
+            message: String
+        ) {
+            Log.d(TAG, "onWarning [$reason]: $message")
         }
 
         override fun onAddRemoteStream(mediaChannel: SoraMediaChannel, ms: MediaStream) {


### PR DESCRIPTION
- [UPDATE] `SoraMediaChannel.Listener` の実装を追加する
  - `onClose` で closeEvent に応じてログを出力するようにした
  - `onWarning` を追加した
  - `onRemoveRemoteStream` を用いてリモートストリームが削除された時に画面をクリアするようにした
  - `onAttendeesCountUpdated` で接続数をログに出力するようにした
  - `onOfferMessage` で Sora から受信した Offer メッセージをログに出力するようにした
  - `onNotificationMessage` で通知内容をログに出力するようにした
 
---

This pull request includes several updates to the `SoraMediaChannel.Listener` implementation in the `MainActivity` class to enhance logging and handle additional events. The changes involve adding new methods and modifying existing ones to improve the application's response to different signaling messages and events.

Enhancements to `SoraMediaChannel.Listener`:

* Added implementation for `onWarning` method to log warning messages.
* Added implementation for `onRemoveRemoteStream` method to clear the screen when a remote stream is removed.
* Added implementation for `onAttendeesCountUpdated` method to log the number of connected attendees.
* Added implementation for `onOfferMessage` and `onNotificationMessage` methods to log received Offer and Notification messages from Sora.
* Updated `onClose` method to provide more detailed logging based on the `closeEvent` code.

Additionally, new imports were added to support these changes:

* `import jp.shiguredo.sora.sdk.channel.data.ChannelAttendeesCount`
* `import jp.shiguredo.sora.sdk.channel.signaling.message.NotificationMessage`
* `import jp.shiguredo.sora.sdk.channel.signaling.message.OfferMessage`