### PR TITLE
GitHub Actions の定期実行をやめる

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ on:
       - 'CHANGES.md'
       - 'LICENSE'
       - 'THANKS'
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,9 @@
 
 ### misc
 
+- [UPDATE] GitHub Actions の定期実行をやめる
+  - @zztkm
+
 ## sora-andoroid-sdk-2025.1.0
 
 **リリース日**: 2025-01-27


### PR DESCRIPTION
- [UPDATE] GitHub Actions の定期実行をやめる

---

This pull request includes changes to the GitHub Actions workflow and updates to the `CHANGES.md` file. The most important changes are as follows:

Changes to GitHub Actions workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L10-L11): Removed the scheduled cron job to stop the periodic execution of GitHub Actions.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R26-R28): Added an entry noting the removal of the periodic execution schedule for GitHub Actions.