### PR TITLE
依存ライブラリのアップデート

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,8 +17,20 @@
 - [CHANGE] `SoraMediaOption` 設定時に `enableMultistream()` を適用しないようにする
   - Sora がデフォルトでレガシーストリームを使用するように設定されている場合、接続エラーになる
   - @zztkm
-- [UPDATE] Sora Android SDK を 2025.2.0-canary.12 にあげる
+- [UPDATE] Sora Android SDK を 2025.2.0-canary.14 にあげる
   - @miosakuma @zztkm
+- [UPDATE] `compileSdkVersion` を 36 に上げる
+  - @miosakuma
+- [UPDATE] `targetSdkVersion` を 36 に上げる
+  - @miosakuma
+- [UPDATE] 依存ライブラリーのバージョンを上げる
+  - com.android.tools.build:gradle を 8.11.1 に上げる
+  - Gradle を 8.14.3 に上げる
+  - com.google.code.gson:gson を 2.13.1 に上げる
+  - @miosakuma
+- [UPDATE] activity_main.xml に `android:fitsSystemWindows="true"` を指定する
+  - targetSdkVersion 35 以降 edge-to-edge が適用される変更に対する対応
+  - @miosakuma
 - [UPDATE] `close` メソッド内で `disableStopButton` を呼び出すようにする
   - `close` は OkHttp のワーカースレッドで実行される可能性があり、ワーカースレッドでは UI を操作できないため、`disableStopButton` を必ず UI スレッドで呼び出すようにした
   - @zztkm

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,8 +28,10 @@
   - Gradle を 8.14.3 に上げる
   - com.google.code.gson:gson を 2.13.1 に上げる
   - @miosakuma
-- [UPDATE] activity_main.xml に `android:fitsSystemWindows="true"` を指定する
-  - targetSdkVersion 35 以降 edge-to-edge が適用される変更に対する対応
+- [UPDATE] edge-to-edge の画面表示に対応する
+  - targetSdkVersion 35 以降 edge-to-edge の画面表示がデフォルトとなった
+  - activity_main.xml に `android:fitsSystemWindows="true"` を指定する
+  - バックグラウンドカラーを白以外にしてステータスバーの文字が見えるようにする
   - @miosakuma
 - [UPDATE] `close` メソッド内で `disableStopButton` を呼び出すようにする
   - `close` は OkHttp のワーカースレッドで実行される可能性があり、ワーカースレッドでは UI を操作できないため、`disableStopButton` を必ず UI スレッドで呼び出すようにした

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
     ext.kotlin_version = '1.9.25'
-    ext.sora_android_sdk_version = '2025.2.0-canary.12'
+    ext.sora_android_sdk_version = '2025.2.0-canary.14'
 
     repositories {
         google()
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.5.0'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlin_version}"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/quickstart/build.gradle
+++ b/quickstart/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 36
 
     defaultConfig {
         applicationId "jp.shiguredo.sora.quickstart"
         minSdkVersion 26
-        targetSdkVersion 33
+        targetSdkVersion 36
         versionCode 1
         versionName "1.0"
 
@@ -68,7 +68,7 @@ ktlint {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}"
 
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
 
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.material:material:1.12.0'

--- a/quickstart/src/main/res/layout/activity_main.xml
+++ b/quickstart/src/main/res/layout/activity_main.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="6dp"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
 
     <Button
         android:id="@+id/startButton"

--- a/quickstart/src/main/res/values/styles.xml
+++ b/quickstart/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:windowBackground">@color/colorPrimary</item>
     </style>
 
 </resources>


### PR DESCRIPTION
- [UPDATE] Sora Android SDK を 2025.2.0-canary.14 にあげる
- [UPDATE] `compileSdkVersion` を 36 に上げる
- [UPDATE] `targetSdkVersion` を 36 に上げる
- [UPDATE] 依存ライブラリーのバージョンを上げる
  - com.android.tools.build:gradle を 8.11.1 に上げる
  - Gradle を 8.14.3 に上げる
  - com.google.code.gson:gson を 2.13.1 に上げる
- [UPDATE] activity_main.xml に `android:fitsSystemWindows="true"` を指定する
  - targetSdkVersion 35 以降 edge-to-edge が適用される変更に対する対応