### PR TITLE
Kotlin バージョン 2.0.20 に上げる

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## 2025.3
 
+- [UPDATE] デバイス権限処理を PermissionDispacher から Activity Result API へ移行
+  - PermissionDispacher が依存していた kapt も不要となったため依存ライブラリから削除
+  - @t-miya
 - [UPDATE] Kotlin バージョンを 2.0.20 に上げる
   - @t-miya
 - [UPDATE] Sora Android SDK を 2025.3.0 に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,9 @@
 ## 2025.3
 
 - [UPDATE] デバイス権限処理を PermissionDispacher から Activity Result API へ移行
-  - PermissionDispacher の更新が 2022 年以降止まっているため
-  - PermissionDispacher が依存していた kapt も不要となったため依存ライブラリから削除
+  - kapt が Kotlin 2 に対応していないため警告が出て 1.9.0 にフォールバックされる
+  - kapt を ksp へ移行しようとすると PermissionDispatcher が対応していないためビルドエラーとなる
+  - PermissionDispatcher は 2022 年以降更新されておらずサードパーティー製ライブラリであるため Google 製の Activity Result API へ移
   - @t-miya
 - [UPDATE] Kotlin バージョンを 2.0.20 に上げる
   - @t-miya

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@
 
 ## 2025.3
 
-- [UPDATE] Sora Android SDK を 2025.3.0 にあげる
+- [UPDATE] Kotlin バージョンを 2.0.20 に上げる
+  - @t-miya
+- [UPDATE] Sora Android SDK を 2025.3.0 に上げる
   - @zztkm
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ## 2025.3
 
 - [UPDATE] デバイス権限処理を PermissionDispacher から Activity Result API へ移行
+  - PermissionDispacher の更新が 2022 年以降止まっているため
   - PermissionDispacher が依存していた kapt も不要となったため依存ライブラリから削除
   - @t-miya
 - [UPDATE] Kotlin バージョンを 2.0.20 に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
 - [UPDATE] デバイス権限処理を PermissionDispacher から Activity Result API へ移行
   - kapt が Kotlin 2 に対応していないため警告が出て 1.9.0 にフォールバックされる
   - kapt を ksp へ移行しようとすると PermissionDispatcher が対応していないためビルドエラーとなる
-  - PermissionDispatcher は 2022 年以降更新されておらずサードパーティー製ライブラリであるため Google 製の Activity Result API へ移
+  - PermissionDispatcher は 2022 年以降更新されておらずサードパーティー製ライブラリであるため Google 製の Activity Result API へ移行
   - @t-miya
 - [UPDATE] Kotlin バージョンを 2.0.20 に上げる
   - @t-miya

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.android.maven) apply false
     alias(libs.plugins.ktlint) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Build tools
 android-gradle-plugin = "8.11.1"
-kotlin = "1.9.25"
+kotlin = "2.0.20"
 ktlint-gradle = "11.3.1"
 versions-plugin = "0.46.0"
 android-maven-plugin = "2.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ sora-android-sdk = "2025.3.0-canary.0"
 gson = "2.13.1"
 androidx-appcompat = "1.7.0"
 material = "1.12.0"
-permissions-dispatcher = "4.9.2"
 
 [libraries]
 # Build tools
@@ -43,9 +42,6 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 material = { module = "com.google.android.material:material", version.ref = "material" }
 
-# Permissions
-permissions-dispatcher = { module = "com.github.permissions-dispatcher:permissionsdispatcher", version.ref = "permissions-dispatcher" }
-permissions-dispatcher-processor = { module = "com.github.permissions-dispatcher:permissionsdispatcher-processor", version.ref = "permissions-dispatcher" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,6 @@ permissions-dispatcher-processor = { module = "com.github.permissions-dispatcher
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 android-maven = { id = "com.github.dcendents.android-maven", version.ref = "android-maven-plugin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versions-plugin" }

--- a/quickstart/build.gradle.kts
+++ b/quickstart/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.ktlint)
 }
 
@@ -77,9 +76,6 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-
-    implementation(libs.permissions.dispatcher)
-    kapt(libs.permissions.dispatcher.processor)
 
     // Sora Android SDK
     if (findProject(":sora-android-sdk") != null) {

--- a/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
+++ b/quickstart/src/main/kotlin/jp/shiguredo/sora/quickstart/MainActivity.kt
@@ -48,7 +48,7 @@ class MainActivity : AppCompatActivity() {
 
     private val permissionsLauncher =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { result ->
-            // 直近リクエストの結果で判定（null 安全）
+            // 直近リクエストの結果で判定
             val allGranted = result.values.all { it == true }
             if (allGranted) {
                 disableStartButton()
@@ -289,11 +289,10 @@ class MainActivity : AppCompatActivity() {
     )
 
     private fun evaluatePermissions(): PermissionCheck {
-        val missing = ArrayList<String>(requiredPermissions.size)
-        for (perm in requiredPermissions) {
-            if (!hasPermission(perm)) missing.add(perm)
-        }
-        return PermissionCheck(missing.isEmpty(), missing.toTypedArray())
+        val missing = requiredPermissions
+            .filterNot(::hasPermission)
+            .toTypedArray()
+        return PermissionCheck(missing.isEmpty(), missing)
     }
 
     private fun close() {


### PR DESCRIPTION
## Activity Result API 移行の経緯
kapt が kotlin2 に対応していないため警告が出て 1.90 にフォールバックされてしまう
-> kapt を ksp へ移行しようとすると PermissionDispatcher が対応していないためビルドエラーとなる
-> PermissionDispatcher 自体が 2022 年移行更新されていない、かつサードパーティー製ライブラリのため Google 製のActivity Result API へ移行する